### PR TITLE
Initial configuration for bettercodehub

### DIFF
--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -1,0 +1,6 @@
+component_depth: 2
+languages:
+- typescript
+- javascript
+exclude:
+  - /src/generated/.*


### PR DESCRIPTION
set component level to 2; 
excluded generated code
