### PR TITLE
UPN Is always visible

### DIFF
--- a/src/components/Admin/UserForm.tsx
+++ b/src/components/Admin/UserForm.tsx
@@ -165,7 +165,8 @@ export const UserForm: FC<UserProps> = ({
               fieldName: string,
               required = false,
               readOnly = false,
-              type?: string
+              type?: string,
+              placeholder?: string
             ) => (
               <Form.Group as={Col}>
                 <Form.Label>
@@ -175,7 +176,7 @@ export const UserForm: FC<UserProps> = ({
                 <Form.Control
                   name={fieldName}
                   type={type || 'text'}
-                  placeholder={title}
+                  placeholder={placeholder || title}
                   value={value}
                   onChange={fieldName === 'tagsets' ? handleTagSet : handleChange}
                   required={required}
@@ -202,7 +203,7 @@ export const UserForm: FC<UserProps> = ({
                 </Form.Row>
                 <Form.Row>
                   {getInputField('Email', email, 'email', true, isReadOnlyMode || isEditMode, 'email')}
-                  {getInputField('UPN', accountUpn, 'upn', false, true)}
+                  {getInputField('Username', accountUpn, 'upn', false, true, 'text', ' ')}
                 </Form.Row>
                 <Form.Row>
                   <Form.Group as={Col} sm={6}>

--- a/src/components/Admin/UserForm.tsx
+++ b/src/components/Admin/UserForm.tsx
@@ -202,7 +202,7 @@ export const UserForm: FC<UserProps> = ({
                 </Form.Row>
                 <Form.Row>
                   {getInputField('Email', email, 'email', true, isReadOnlyMode || isEditMode, 'email')}
-                  {accountUpn !== '' && getInputField('UPN', accountUpn, 'upn', false, true)}
+                  {getInputField('UPN', accountUpn, 'upn', false, true)}
                 </Form.Row>
                 <Form.Row>
                   <Form.Group as={Col} sm={6}>


### PR DESCRIPTION
### Describe the background of your pull request

Now the UPN field is always visible

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [x] I've read the contributing document https://github.com/cherrytwist/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/cherrytwist/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/cherrytwist/Coordination/blob/master/LICENSE 
     and the contributor license agreement: tba
 
