### PR TITLE
Updated regex used for phone number validaton

### DIFF
--- a/src/components/Admin/UserForm.tsx
+++ b/src/components/Admin/UserForm.tsx
@@ -84,7 +84,7 @@ export const UserForm: FC<UserProps> = ({
     country: yup.string(),
     phone: yup
       .string()
-      .matches(/^[+]?\d+$/, 'Phone number may contain only numbers. Sign "+" is allowed only at the start'),
+      .matches(/^[\+]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,6}$/im, 'Phone number not in supported format'),
     avatar: yup.string(),
     tagsets: yup.array().of(
       yup.object().shape({


### PR DESCRIPTION
Previous regex was blocking the saving of phone numbers that are valid and that are already in production
 
